### PR TITLE
Changes from background agent bc-7d5b7081-05b0-4400-8f54-bb78c1713258

### DIFF
--- a/AISnake
+++ b/AISnake
@@ -2306,8 +2306,13 @@ AISnake._brainConnection = RunService.Stepped:Connect(function(time, deltaTime)
 			end
 		end
 
-		for _, orb in OrbUtils.orbs do
-			SpatialGrid.Insert(orb, orb, "ORB")
+		-- Insert orbs into spatial grid if OrbUtils.orbs exists
+		if OrbUtils.orbs and type(OrbUtils.orbs) == "table" then
+			for _, orb in pairs(OrbUtils.orbs) do
+				if orb and orb.Parent then
+					SpatialGrid.Insert(orb, orb, "ORB")
+				end
+			end
 		end
 	end 
 


### PR DESCRIPTION
Safeguard `AISnake` module's spatial grid update to prevent errors when `OrbUtils.orbs` is not yet initialized or contains nil values.

This fixes an `invalid argument #1 to 'ipairs' (table expected, got nil)` error in `AISnake` by ensuring `OrbUtils.orbs` is a valid table and its contents are not nil before iterating, preventing crashes due to module loading order or unexpected orb states.

---

[Open in Web](https://cursor.com/agents?id=bc-7d5b7081-05b0-4400-8f54-bb78c1713258) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7d5b7081-05b0-4400-8f54-bb78c1713258) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)